### PR TITLE
Update and rename test_validator.py to test_person_validator.py

### DIFF
--- a/test_person_validator.py
+++ b/test_person_validator.py
@@ -22,7 +22,7 @@ class TestPersonValidator(unittest.TestCase):
 
     def test_validate_person_name_non_string(self):
         """Test if the validator raises an error for a non-string for name"""
-        with self.assertRaises(ValueError) as e:
+        with self.assertRaises(TypeError) as e:
             self.validator.validate_person_name(12)
         self.assertEqual(str(e.exception), PersonMessages.INVALID_STRING, "Person-Non-String: Assertion Failed!")
 
@@ -46,7 +46,7 @@ class TestPersonValidator(unittest.TestCase):
 
     def test_validate_person_address_non_string(self):
         """Test if the validator raises an error for a non-string for address"""
-        with self.assertRaises(ValueError) as e:
+        with self.assertRaises(TypeError) as e:
             self.validator.validate_person_address(12)
         self.assertEqual(str(e.exception), PersonMessages.INVALID_ADDRESS_TYPE, "Address-Non-String: Assertion Failed!")
 
@@ -90,7 +90,7 @@ class TestPersonValidator(unittest.TestCase):
 
     def test_validate_person_email_non_string(self):
         """Test if the validator raises an error for a non-string for email"""
-        with self.assertRaises(ValueError) as e:
+        with self.assertRaises(TypeError) as e:
             self.validator.validate_person_email(12)
         self.assertEqual(str(e.exception), PersonMessages.INVALID_EMAIL, "Email-Non-String: Assertion Failed!")
 


### PR DESCRIPTION
**Changes:**
* renamed test_validator.py to test_person_validator.py
* For all non_string functions, replaced ValueError with TypeError to be more aligned with the expected data type handling!

**Note:**
As for the suggestion raised by William in the Suggestions.md with "test_validate_phone_number_non_integer()", ValueError will be a custom raised exception in the code if phone number is not a string composed of the characters **1-9**